### PR TITLE
Add Build and Push Image actions to GAR

### DIFF
--- a/.github/workflows/build_image_and_push_to_gar.yml
+++ b/.github/workflows/build_image_and_push_to_gar.yml
@@ -1,0 +1,37 @@
+name: Build and Push Image
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build-and-publish:
+    name: Build and Push docker image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.ref }}
+
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v1'
+      with:
+        credentials_json: '${{ secrets.GCLOUD_AUTH }}'
+
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
+
+    - name: Configure docker for artifact registry
+      run: |
+        gcloud auth configure-docker asia-northeast1-docker.pkg.dev
+
+    - name: Build
+      run: |
+        docker build -f ./docker/Dockerfile -t asia-northeast1-docker.pkg.dev/turing-alcove-157907/poke-battle-logger-api/production-image:${{ github.sha }} ./
+
+    - name: Push
+      run: |
+        docker push asia-northeast1-docker.pkg.dev/turing-alcove-157907/poke-battle-logger-api/production-image:${{ github.sha }}


### PR DESCRIPTION
#11 デプロイ先を cloud run にします。
このPR では main ブランチが更新された際 google cloud artifact registry に自動で build, push する actions を追加します